### PR TITLE
Add Travis deployment files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+language: node_js
+node_js: node
+install:
+- travis_retry gem install s3_website -v 3.4.0
+- travis_retry pip install awscli --upgrade --user
+- travis_retry npm install
+script:
+- npm run build
+after_script:
+- ./s3_deploy.sh
+cache:
+  bundler: true
+  directories:
+    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: node
+node_js: lts/*
 install:
 - travis_retry gem install s3_website -v 3.4.0
 - travis_retry pip install awscli --upgrade --user

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shared Tables CODAP Plugin
+# CODAP Shared Table Plugin
 
 ### Initial steps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "codap-plugin-starter-project",
   "version": "0.1.0",
+  "homepage": ".",
   "dependencies": {
     "firebase": "^5.8.6",
     "iframe-phone": "^1.2.0",

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SRC_DIR='build'
-DISTRIBUTION_ID='E2JWFZUT1461ZF'
+DISTRIBUTION_ID='E3P78ES085CH6O'
 # name of branch to deploy to root of site
 PRODUCTION_BRANCH='production'
 

--- a/s3_deploy.sh
+++ b/s3_deploy.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+SRC_DIR='build'
+DISTRIBUTION_ID='E2JWFZUT1461ZF'
+# name of branch to deploy to root of site
+PRODUCTION_BRANCH='production'
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+	echo "skipping deploy to S3: this is a pull request"
+	exit 0
+fi
+
+# extract current TAG if present
+# the 2> is to prevent error messages when no match is found
+CURRENT_TAG=`git describe --tags --exact-match $TRAVIS_COMMIT 2> /dev/null`
+
+# strip PT ID from branch name for branch builds
+DEPLOY_DIR_NAME=$TRAVIS_BRANCH
+PT_PREFIX_REGEX="^([0-9]{8,}-)(.+)$"
+PT_SUFFIX_REGEX="^(.+)(-[0-9]{8,})$"
+if [[ $DEPLOY_DIR_NAME =~ $PT_PREFIX_REGEX ]]; then
+  DEPLOY_DIR_NAME=${BASH_REMATCH[2]}
+fi
+if [[ $DEPLOY_DIR_NAME =~ $PT_SUFFIX_REGEX ]]; then
+  DEPLOY_DIR_NAME=${BASH_REMATCH[1]}
+fi
+
+# tagged builds deploy to /version/TAG_NAME
+if [ "$TRAVIS_BRANCH" = "$CURRENT_TAG" ]; then
+  mkdir -p _site/version
+  S3_DEPLOY_DIR="version/$TRAVIS_BRANCH"
+  DEPLOY_DEST="_site/$S3_DEPLOY_DIR"
+  INVAL_PATH="/version/$TRAVIS_BRANCH/index.html"
+  # used by s3_website.yml
+  export S3_DEPLOY_DIR
+
+# production branch builds deploy to root of site
+elif [ "$TRAVIS_BRANCH" = "$PRODUCTION_BRANCH" ]; then
+  DEPLOY_DEST="_site"
+  INVAL_PATH="/index.html"
+
+# branch builds deploy to /branch/BRANCH_NAME
+else
+  mkdir -p _site/branch
+  S3_DEPLOY_DIR="branch/$DEPLOY_DIR_NAME"
+  DEPLOY_DEST="_site/$S3_DEPLOY_DIR"
+  INVAL_PATH="/branch/$DEPLOY_DIR_NAME/index.html"
+  # used by s3_website.yml
+  export S3_DEPLOY_DIR
+fi
+
+# copy files to destination
+mv $SRC_DIR $DEPLOY_DEST
+
+# deploy the site contents
+s3_website push --site _site
+
+# explicit CloudFront invalidation to workaround s3_website gem invalidation bug
+# with origin path (https://github.com/laurilehmijoki/s3_website/issues/207).
+aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths $INVAL_PATH

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,0 +1,30 @@
+s3_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+s3_secret: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+s3_bucket: models-resources
+s3_key_prefix: shared-table-codap-plugin
+s3_endpoint: us-east-1
+gzip: true
+
+cloudfront_distribution_id: E2JWFZUT1461ZF
+cloudfront_invalidate_root: true
+cloudfront_wildcard_invalidation: true
+
+<% if ENV['TRAVIS_BRANCH'] == 'production' %>
+# in this case we are going to deploy this branch to the top level of the domain
+# so we need to ignore the version and branch folders
+ignore_on_server: ^shared-table-codap-plugin/(version/|branch/)
+<% else %>
+# in this case we are going to deploy this code to a subfolder of either the branch
+# or version folder. So ignore everything except this folder.
+ignore_on_server: ^(?!shared-table-codap-plugin/<%= Regexp.escape(ENV['S3_DEPLOY_DIR']) %>/)
+<% end %>
+max_age:
+  "shared-table-codap-plugin/*": 600 # 10 minutes
+  "shared-table-codap-plugin/version/*": 31536000 # 1 year
+  "shared-table-codap-plugin/branch/*": 0
+
+cloudfront_distribution_config:
+  aliases:
+    quantity: 1
+    items:
+      - shared-table-codap-plugin.concord.org

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,30 +1,30 @@
 s3_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
 s3_secret: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
 s3_bucket: models-resources
-s3_key_prefix: shared-table-codap-plugin
+s3_key_prefix: codap-shared-table-plugin
 s3_endpoint: us-east-1
 gzip: true
 
-cloudfront_distribution_id: E2JWFZUT1461ZF
+cloudfront_distribution_id: E3P78ES085CH6O
 cloudfront_invalidate_root: true
 cloudfront_wildcard_invalidation: true
 
 <% if ENV['TRAVIS_BRANCH'] == 'production' %>
 # in this case we are going to deploy this branch to the top level of the domain
 # so we need to ignore the version and branch folders
-ignore_on_server: ^shared-table-codap-plugin/(version/|branch/)
+ignore_on_server: ^codap-shared-table-plugin/(version/|branch/)
 <% else %>
 # in this case we are going to deploy this code to a subfolder of either the branch
 # or version folder. So ignore everything except this folder.
-ignore_on_server: ^(?!shared-table-codap-plugin/<%= Regexp.escape(ENV['S3_DEPLOY_DIR']) %>/)
+ignore_on_server: ^(?!codap-shared-table-plugin/<%= Regexp.escape(ENV['S3_DEPLOY_DIR']) %>/)
 <% end %>
 max_age:
-  "shared-table-codap-plugin/*": 600 # 10 minutes
-  "shared-table-codap-plugin/version/*": 31536000 # 1 year
-  "shared-table-codap-plugin/branch/*": 0
+  "codap-shared-table-plugin/*": 600 # 10 minutes
+  "codap-shared-table-plugin/version/*": 31536000 # 1 year
+  "codap-shared-table-plugin/branch/*": 0
 
 cloudfront_distribution_config:
   aliases:
     quantity: 1
     items:
-      - shared-table-codap-plugin.concord.org
+      - codap-shared-table-plugin.concord.org


### PR DESCRIPTION
Adds Travis deployment files.

The subdomain shared-table-codap-plugin.concord.org has been created. I'm not sure whether we really need a subdomain for this, but it would make the cloud front invalidations harder to run it straight from models resources. It's a long domain, and could be made shorter, but I believe we eventually expect users to pull it in from the plugins list, so it probably is unimportant.

Travis page: https://travis-ci.com/concord-consortium/shared-table-codap-plugin/

Latest deployment: https://shared-table-codap-plugin.concord.org/branch/travis-deploy/