### PR TITLE
Initial support for joining a shared table with an existing table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,7 +272,7 @@ class App extends Component {
       if (!existingDataContext) {
         // add collaborator name case if necessary
         if (!items || !items[this.state.personalDataLabel]) {
-          Codap.createUserCase(dataContext.name, this.state.personalDataLabel);
+          Codap.configureUserCase(dataContext.name, this.state.personalDataLabel, true);
         }
       }
       else {

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -9,7 +9,7 @@ export interface DataContext {
 const dataContextResource = (contextName: string, subKey?: string) =>
                               `dataContext[${contextName}]${subKey ? "." + subKey : ""}`;
 const collaboratorsResource = (contextName: string, subKey: string) =>
-                                `dataContext[${contextName}].collection[Collaborators]${subKey}`;
+                                `dataContext[${contextName}].collection[Collaborators].${subKey}`;
 
 export class CodapHelper {
 


### PR DESCRIPTION
Two cases are currently supported:
- initial shared table and joining table are both newly created ("Create new table" option)
- initial shared table and joining table are both previously created with default name ("New Dataset")

More complicated merge possibilities are left as future enhancements.

This PR relies on a new CODAP plugin API endpoint, `itemCount`, which is implemented in [CODAP PR #268](https://github.com/concord-consortium/codap/pull/268), which has now been merged into build 0478.

@sfentress I've added a commit which makes the improvements you suggested. This should be ready for re-review.