### PR TITLE
Move the user's case(s) to last in the table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -291,6 +291,7 @@ class App extends Component {
           }
         }
         else {
+          Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
           this.writeUserItems(selectedDataContext, personalDataLabel);
         }
 

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -197,4 +197,26 @@ export class CodapHelper {
     }
     return [];
   }
+
+  static async getCaseForCollaborator(dataContextName: string, name: string): Promise<any> {
+    const res = await codapInterface.sendRequest({
+      action: "get",
+      resource: collaboratorsResource(dataContextName, `caseSearch[Name==${name}]`)
+    });
+    // there should be only one such case
+    return res.success && res.values && res.values.length ? res.values[0] : null;
+  }
+
+  static async moveUserCaseToLast(dataContextName: string, name: string): Promise<boolean> {
+    const aCase = await this.getCaseForCollaborator(dataContextName, name);
+    if (aCase && aCase.id) {
+      const res = await codapInterface.sendRequest({
+        action: "update",
+        resource: collaboratorsResource(dataContextName, `caseByID[${aCase.id}]`),
+        values: { caseOrder: "last" }
+      });
+      return res.success;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
Note that this takes advantage of a new CODAP plugin API endpoint implemented in [CODAP PR #269](https://github.com/concord-consortium/codap/pull/269). In the absence of that CODAP feature, the request to change the case order will simply fail.

This PR is based on #11  and #13 to avoid future merge conflicts. Those PRs should be reviewed/rebased/merged first before rebasing/merging this one. Those PRs have now been merged and this PR is rebased to master.