### PR TITLE
Unique data context names

### DIFF
--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -1,9 +1,13 @@
+import * as randomize from "randomatic";
 import codapInterface, { CodapApiResponse, ClientHandler, Collection } from "./CodapInterface";
 
-export interface DataContext {
-  name: string;
+export interface DataContextCreation {
   title: string;
   collections?: any[];
+}
+
+export interface DataContext extends DataContextCreation {
+  name: string;
 }
 
 const dataContextResource = (contextName: string, subKey?: string) =>
@@ -42,36 +46,13 @@ export class CodapHelper {
     return [];
   }
 
-  // if passed "foo" returns "foo-1"
-  // if passed "foo-bar-23" returns "foo-bar-24"
-  static incrementName(name: string) {
-    if (/-(\d*)$/.test(name)) {
-      const count = /-(\d*)$/.exec(name)![1];
-      const next = "" + (parseInt(count, 10) + 1);
-      return name.replace(/\d*$/, next);
-    } else {
-      return name + "-1";
-    }
-  }
-
-  static async createUniqueDataContext(dataContextPrefix: string, title: string) {
-    const contexts = await this.getDataContextList();
-    const contextNames: string[] = contexts.map((c: DataContext) => c.name);
-    let newDataContextName = dataContextPrefix;
-    while (contextNames.indexOf(newDataContextName) > -1) {
-      newDataContextName = this.incrementName(newDataContextName);
-    }
-    const newContext = await this.createDataContext({ name: newDataContextName, title });
-    return newContext;
-  }
-
-  static async createDataContext(dataContextSpec: DataContext): Promise<DataContext | null> {
-    const { name, title, collections } = dataContextSpec;
+  static async createDataContext(dataContextSpec: DataContextCreation): Promise<DataContext | null> {
+    const { title, collections } = dataContextSpec;
     const res = await codapInterface.sendRequest({
       action: "create",
       resource: "dataContext",
       values: {
-        name,
+        name: randomize("a0", 10),
         title,
         collections: collections || []
       }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,6 +7,28 @@ const config = {
   databaseURL: "https://codap-shared-table-plugin.firebaseio.com"
 };
 
+/**
+ * Recursively traverses objects and arrays to remove any properties with
+ * the key `id` or `guid`. This mutates the original object.
+ *
+ * These properties only make sense within the context of an individual's own
+ * CODAP document, and cause problems when shared between different documents.
+ *
+ * @param obj
+ */
+function removeIds(obj: any) {
+  if (!obj) return;
+  if (Array.isArray(obj)) {
+    obj.forEach(removeIds);
+  } else if (typeof obj === "object") {
+    delete obj.id;
+    delete obj.guid;
+    for (const prop of Object.keys(obj)) {
+      removeIds(obj[prop]);
+    }
+  }
+}
+
 export class DB {
   shareRef?: firebase.database.Reference;
 
@@ -89,6 +111,7 @@ export class DB {
   // adds data at `shared-tables/${shareId}/${key}`
   set(key: string, data: any) {
     if (this.shareRef) {
+      removeIds(data);
       this.shareRef.child(key).set(data);
     }
   }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,20 +11,24 @@ const config = {
  * Recursively traverses objects and arrays to remove any properties with
  * the key `id` or `guid`. This mutates the original object.
  *
- * These properties only make sense within the context of an individual's own
- * CODAP document, and cause problems when shared between different documents.
+ * For objects such as DataContexts and Collections, these properties only make sense
+ * within the context of an individual's own CODAP document, and cause problems when
+ * shared between different documents.
+ *
+ * If the IDs are needed for references even across shares this function should not
+ * be used.
  *
  * @param obj
  */
-function removeIds(obj: any) {
+function removeLocalDocumentIds(obj: any) {
   if (!obj) return;
   if (Array.isArray(obj)) {
-    obj.forEach(removeIds);
+    obj.forEach(removeLocalDocumentIds);
   } else if (typeof obj === "object") {
     delete obj.id;
     delete obj.guid;
     for (const prop of Object.keys(obj)) {
-      removeIds(obj[prop]);
+      removeLocalDocumentIds(obj[prop]);
     }
   }
 }
@@ -111,7 +115,7 @@ export class DB {
   // adds data at `shared-tables/${shareId}/${key}`
   set(key: string, data: any) {
     if (this.shareRef) {
-      removeIds(data);
+      removeLocalDocumentIds(data);
       this.shareRef.child(key).set(data);
     }
   }


### PR DESCRIPTION
This PR is on top of #14, and  can be rebased when that is merged.

This 

1. Always uses random data context names whenever the plugin creates a DC, either by starting a share with a new table or when joining a share, and

2. Strips out ids and guids from all objects shared to Firebase.