### PR TITLE
Merge tables on join

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,7 +230,7 @@ class App extends Component {
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       if (updatedNewContext) {
-        const sharableDataContext = Codap.getSharableDataContext(updatedNewContext);
+        const sharableDataContext = await Codap.getSharableDataContext(updatedNewContext);
         database.set("dataContext", sharableDataContext);
       }
     }
@@ -271,6 +271,9 @@ class App extends Component {
           ownDataContextName = selectedDataContext;
           await Codap.addNewCollaborationCollections(selectedDataContext, personalDataLabel, false);
           await Codap.mergeDataContexts(selectedDataContext, sharedDataContext);
+
+          const sharableDataContext = await Codap.getSharableDataContext(selectedDataContext);
+          database.set("dataContext", sharableDataContext);
         }
 
         // combine items from all users in a single array

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,7 +230,8 @@ class App extends Component {
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       if (updatedNewContext) {
-        database.set("dataContext", updatedNewContext);
+        const sharableDataContext = Codap.getSharableDataContext(updatedNewContext);
+        database.set("dataContext", sharableDataContext);
       }
     }
     finally {
@@ -258,14 +259,6 @@ class App extends Component {
                                     await Codap.getDataContext(selectedDataContext);
 
         if (!existingDataContext) {
-          // fix parent references -- assumes collections are written out in order
-          const collectionNames: string[] = [];
-          sharedDataContext.collections.forEach((collection: any, index: number) => {
-            collectionNames.push(collection.name);
-            if (index > 0) {
-              collection.parent = collectionNames[index - 1];
-            }
-          });
           const newDataContext = await Codap.createDataContext(sharedDataContext);
           if (newDataContext) {
             ownDataContextName = newDataContext.name;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,6 +270,7 @@ class App extends Component {
         else {
           ownDataContextName = selectedDataContext;
           await Codap.addNewCollaborationCollections(selectedDataContext, personalDataLabel, false);
+          await Codap.mergeDataContexts(selectedDataContext, sharedDataContext);
         }
 
         // combine items from all users in a single array

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { Component, ChangeEvent } from "react";
 import * as randomize from "randomatic";
 import { CodapHelper as Codap, DataContext} from "./lib/codap-helper";
 import { ClientNotification } from "./lib/CodapInterface";
-import { DB } from "./lib/db";
+import { DB, SharedTableEntry } from "./lib/db";
 const pkg = require("../package.json");
 import "./App.css";
 
@@ -251,7 +251,7 @@ class App extends Component {
       this.setState({shareId});
 
       const response = await database.getAll();
-      const sharedContextData = response && response.val();
+      const sharedContextData = response && response.val() as SharedTableEntry | undefined;
       let ownDataContextName;
       if (sharedContextData) {
         const { dataContext: sharedDataContext, items } = sharedContextData;

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -103,7 +103,7 @@ export interface ClientNotification {
 }
 export type ClientHandler = (notification: ClientNotification) => void;
 
-export interface Attributes {
+export interface Attribute {
   name: string;
   editable?: boolean;
 }
@@ -121,7 +121,7 @@ export interface Collection {
     setOfCases?: string;
     setOfCasesWithArticle?: string;
   },
-  attrs: Attributes[]
+  attrs: Attribute[]
 }
 
 /**

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -111,7 +111,8 @@ export interface Attributes {
 export interface Collection {
   name: string;
   title: string;
-  parent?: string;
+  id?: number;
+  parent?: string | number;
   description?: string;
   labels?: {
     singleCase?: string;

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -75,7 +75,14 @@ export class CodapHelper {
    * when we get the DC from CODAP, to be the names of the parent collections. These names can be used on
    * collection creation, and will survive sharing between documents.
    */
-  static getSharableDataContext(dataContext: DataContext) {
+  static async getSharableDataContext(_dataContext: DataContext | string) {
+    let dataContext;
+    if (typeof _dataContext === "string") {
+      dataContext = await this.getDataContext(_dataContext);
+      if (!dataContext) return;
+    } else {
+      dataContext = _dataContext;
+    }
     const sharableDataContext: DataContext = JSON.parse(JSON.stringify(dataContext));
     sharableDataContext.collections.forEach(collection => {
       const parentId = collection.parent;

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -1,5 +1,5 @@
 import * as randomize from "randomatic";
-import codapInterface, { CodapApiResponse, ClientHandler, Collection, Attributes } from "./CodapInterface";
+import codapInterface, { CodapApiResponse, ClientHandler, Collection, Attribute } from "./CodapInterface";
 
 export interface DataContextCreation {
   title: string;
@@ -15,13 +15,15 @@ interface AttributeMeta {
   name: string;
   collection: string;
   index: number;
-  attr: Attributes;
+  attr: Attribute;
 }
 
 const dataContextResource = (contextName: string, subKey?: string) =>
                               `dataContext[${contextName}]${subKey ? "." + subKey : ""}`;
+const collectionResource = (contextName: string, collectionName: string, subKey?: string) =>
+                              `dataContext[${contextName}].collection[${collectionName}]${subKey ? "." + subKey : ""}`;
 const collaboratorsResource = (contextName: string, subKey: string) =>
-                                `dataContext[${contextName}].collection[Collaborators].${subKey}`;
+                              collectionResource(contextName, "Collaborators", subKey);
 
 export class CodapHelper {
 
@@ -248,8 +250,7 @@ export class CodapHelper {
           if (newLocation) {
             return {
               action: "update",
-              // tslint:disable-next-line:max-line-length
-              resource: dataContextResource(existingDataContextName, `collection[${attr.collection}].attributeLocation[${attr.name}]`),
+              resource: collectionResource(existingDataContextName, attr.collection, `attributeLocation[${attr.name}]`),
               values: {
                 collection: newLocation.collection,
                 position: newLocation.index

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,11 +1,18 @@
 import * as firebase from "firebase/app";
 import "firebase/database";
+import { DataContext } from "./codap-helper";
 
 const config = {
   apiKey: "AIzaSyASCGi9fWCUX3orJVB9d6svJbxDHfSRJVA",
   authDomain: "codap-shared-table-plugin.firebaseapp.com",
   databaseURL: "https://codap-shared-table-plugin.firebaseio.com"
 };
+
+export interface SharedTableEntry {
+  connectedUsers: string[];
+  dataContext: DataContext;
+  items?: {[key: string]: any[]};
+}
 
 /**
  * Recursively traverses objects and arrays to remove any properties with


### PR DESCRIPTION
This takes an existing table and an incoming shared table and merges the latter into the former, such that any new collections are created, any new attributes are created, and any existing attributes are moved into new locations if necessary.

All collections and attributes in the existing table that are not in the shared one are maintained, thus the merged table may be larger. The resulting table is then shared back to the database.

This PR is on top of #15