### PR TITLE
Allow collection reorganization

### DIFF
--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -66,15 +66,21 @@ var stats = {
   timeCodapLastReq: (null as Date | null)
 };
 
+export interface IDimensions {
+  width: number;
+  height: number;
+}
+
 export interface IConfig {
   stateHandler?: (arg0: any) => void;
   customInteractiveStateHandler?: boolean;
   name?: string;
   title?: string;
   version?: string;
-  dimensions?: any;
+  dimensions?: IDimensions;
   preventBringToFront?: boolean;
   preventDataContextReorg?: boolean;
+  preventTopLevelReorg?: boolean;
 }
 
 var config: IConfig | null = null;
@@ -248,14 +254,7 @@ const codapInterface = {
       }
 
       var getFrameReq = {action: 'get', resource: 'interactiveFrame'};
-      var newFrame = {
-        name: iConfig.name,
-        title: iConfig.title,
-        version: iConfig.version,
-        dimensions: iConfig.dimensions,
-        preventBringToFront: iConfig.preventBringToFront,
-        preventDataContextReorg: iConfig.preventDataContextReorg
-      };
+      var { stateHandler, customInteractiveStateHandler, ...newFrame } = iConfig;
       var updateFrameReq = {
         action: 'update',
         resource: 'interactiveFrame',
@@ -268,7 +267,7 @@ const codapInterface = {
       connection = new IframePhoneRpcEndpoint(
           notificationHandler, "data-interactive", window.parent);
 
-      if (!config.customInteractiveStateHandler) {
+      if (!customInteractiveStateHandler) {
         this_.on('get', 'interactiveState', function () {
           return ({success: true, values: this_.getInteractiveState()});
         }.bind(this_));

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -66,15 +66,15 @@ var stats = {
   timeCodapLastReq: (null as Date | null)
 };
 
-interface IConfig {
+export interface IConfig {
   stateHandler?: (arg0: any) => void;
   customInteractiveStateHandler?: boolean;
-  name?: any;
-  title?: any;
-  version?: any;
+  name?: string;
+  title?: string;
+  version?: string;
   dimensions?: any;
-  preventBringToFront?: any;
-  preventDataContextReorg?: any;
+  preventBringToFront?: boolean;
+  preventDataContextReorg?: boolean;
 }
 
 var config: IConfig | null = null;

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -39,6 +39,7 @@ export class CodapHelper {
       name: pluginName,
       version,
       preventDataContextReorg: false,
+      preventTopLevelReorg: true,
       dimensions
     };
     return await codapInterface.init(interfaceConfig);

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -1,5 +1,5 @@
 import * as randomize from "randomatic";
-import codapInterface, { CodapApiResponse, ClientHandler, Collection, Attribute } from "./CodapInterface";
+import codapInterface, { CodapApiResponse, ClientHandler, Collection, Attribute, IConfig } from "./CodapInterface";
 import { ClientItemValues } from "./firebase-handlers";
 
 export interface DataContextCreation {
@@ -35,9 +35,10 @@ export class CodapHelper {
 
   static async initializePlugin(pluginName: string, version: string,
                           dimensions: {width: number, height: number}) {
-    const interfaceConfig = {
+    const interfaceConfig: IConfig = {
       name: pluginName,
       version,
+      preventDataContextReorg: false,
       dimensions
     };
     return await codapInterface.init(interfaceConfig);


### PR DESCRIPTION
Note: While in the neighborhood, I also added a `preventTopLevelReorg` flag (which currently has no effect) to prevent dragging attributes above the `Collaborators` collection in the hierarchy. A CODAP PR to support that flag will be submitted shortly.