### PR TITLE
Save unique user key and last username

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const kNewDataContextTitle = "Collaborative Table";
 interface IState {
   availableDataContexts: DataContext[];
   selectedDataContext: string;
+  personalDataKey: string;
   personalDataLabel: string;
   shareId?: string;
   joinShareId: string;
@@ -41,6 +42,7 @@ class App extends Component {
   public state: IState = {
     availableDataContexts: [],
     selectedDataContext: kNewSharedTable,
+    personalDataKey: randomize("a0", 10),
     personalDataLabel: "",
     joinShareId: "",
     isInProcessOfSharing: false,
@@ -181,19 +183,19 @@ class App extends Component {
 
     this.updateAvailableDataContexts(); // existing dataContext name may have changed
 
-    const { shareId, selectedDataContext, personalDataLabel } = this.state;
+    const { shareId, selectedDataContext, personalDataKey } = this.state;
     if (shareId) {
       // update data context details
       this.writeDataContext(selectedDataContext);
 
-      this.writeUserItems(selectedDataContext, personalDataLabel);
-      Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
+      this.writeUserItems(selectedDataContext, personalDataKey);
+      Codap.moveUserCaseToLast(selectedDataContext, personalDataKey);
     }
   }
 
-  async writeUserItems(selectedDataContext: string, personalDataLabel: string) {
-    const items = await Codap.getItemsOfCollaborator(selectedDataContext, personalDataLabel);
-    database.setUserItems(personalDataLabel, items);
+  async writeUserItems(selectedDataContext: string, personalDataKey: string) {
+    const items = await Codap.getItemsOfCollaborator(selectedDataContext, personalDataKey);
+    database.setUserItems(personalDataKey, items);
   }
 
   updateSelectedDataContext = (event: ChangeEvent<HTMLSelectElement>) => {
@@ -209,7 +211,7 @@ class App extends Component {
   }
 
   initiateShare = async () => {
-    const {selectedDataContext, personalDataLabel} = this.state;
+    const {selectedDataContext, personalDataKey, personalDataLabel} = this.state;
     let dataContextName: string;
 
     this.setState({ isInProcessOfSharing: true });
@@ -220,7 +222,7 @@ class App extends Component {
         if (newContext) {
           dataContextName = newContext.name;
           this.setState({selectedDataContext: dataContextName});
-          await Codap.addNewCollaborationCollections(dataContextName, personalDataLabel, true);
+          await Codap.addNewCollaborationCollections(dataContextName, personalDataKey, personalDataLabel, true);
           Codap.openTable(dataContextName);
         } else {
           throw new Error("failed to create new data context");
@@ -230,8 +232,8 @@ class App extends Component {
         if (newContext) {
           dataContextName = newContext.name;
           this.setState({selectedDataContext: dataContextName});
-          await Codap.addNewCollaborationCollections(dataContextName, personalDataLabel, false);
-          this.writeUserItems(selectedDataContext, personalDataLabel);
+          await Codap.addNewCollaborationCollections(dataContextName, personalDataKey, personalDataLabel, false);
+          this.writeUserItems(selectedDataContext, personalDataKey);
         } else {
           throw new Error("failed to update data context");
         }
@@ -239,7 +241,7 @@ class App extends Component {
 
       const shareId = randomize("a0", kShareIdLength, { exclude: "0oOiIlL1" });
       this.setState({shareId});
-      database.createSharedTable(shareId, personalDataLabel);
+      database.createSharedTable(shareId, personalDataKey);
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       await this.writeDataContext(updatedNewContext);
@@ -252,11 +254,11 @@ class App extends Component {
   }
 
   joinShare = async () => {
-    const {joinShareId: shareId, personalDataLabel, selectedDataContext } = this.state;
+    const {joinShareId: shareId, personalDataKey, personalDataLabel, selectedDataContext } = this.state;
 
     this.setState({ isInProcessOfSharing: true });
     try {
-      if (!await database.joinSharedTable(shareId, personalDataLabel)) {
+      if (!await database.joinSharedTable(shareId, personalDataKey)) {
         this.setState({ showJoinShareError: true });
         return;
       }
@@ -281,8 +283,9 @@ class App extends Component {
         }
         else {
           ownDataContextName = selectedDataContext;
-          await Codap.addNewCollaborationCollections(selectedDataContext, personalDataLabel, false);
+          await Codap.addNewCollaborationCollections(selectedDataContext, personalDataKey, personalDataLabel, false);
           await Codap.syncDataContexts(selectedDataContext, sharedDataContext, true);
+
           await this.writeDataContext(selectedDataContext);
         }
 
@@ -291,13 +294,13 @@ class App extends Component {
 
         if (!existingDataContext) {
           // add collaborator name case if necessary
-          if (!items || !items[this.state.personalDataLabel]) {
-            Codap.configureUserCase(ownDataContextName, this.state.personalDataLabel, true);
+          if (!items || !items[personalDataKey]) {
+            Codap.configureUserCase(ownDataContextName, personalDataKey, personalDataLabel, true);
           }
         }
         else {
-          Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
-          this.writeUserItems(selectedDataContext, personalDataLabel);
+          Codap.moveUserCaseToLast(selectedDataContext, personalDataKey);
+          this.writeUserItems(selectedDataContext, personalDataKey);
         }
 
         database.addListener("dataContext", this.synchronizeDataContext);
@@ -325,21 +328,21 @@ class App extends Component {
   }
 
   itemsAdded = async (user: string, items: ClientItemValues[]) => {
-    const { selectedDataContext, personalDataLabel } = this.state;
+    const { selectedDataContext, personalDataKey } = this.state;
     await Codap.createOrUpdateItems(selectedDataContext, items);
-    Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
+    Codap.moveUserCaseToLast(selectedDataContext, personalDataKey);
   }
 
   itemsChanged = async (user: string, items: ClientItemValues[]) => {
-    const { selectedDataContext, personalDataLabel } = this.state;
+    const { selectedDataContext, personalDataKey } = this.state;
     await Codap.createOrUpdateItems(selectedDataContext, items);
-    Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
+    Codap.moveUserCaseToLast(selectedDataContext, personalDataKey);
   }
 
   itemsRemoved = async (user: string, items: ClientItemValues[]) => {
-    const { selectedDataContext, personalDataLabel } = this.state;
+    const { selectedDataContext, personalDataKey } = this.state;
     await Codap.removeItems(selectedDataContext, items);
-    Codap.moveUserCaseToLast(selectedDataContext, personalDataLabel);
+    Codap.moveUserCaseToLast(selectedDataContext, personalDataKey);
   }
 }
 

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -112,6 +112,7 @@ export type ClientHandler = (notification: ClientNotification) => void;
 export interface Attribute {
   name: string;
   editable?: boolean;
+  hidden?: boolean;
 }
 
 export interface Collection {

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -206,7 +206,7 @@ export class CodapHelper {
         },
         attrs: [
           {name: "Name", editable: false},
-          {name: kCollaboratorKey, editable: false}
+          {name: kCollaboratorKey, editable: false, hidden: true}
         ]
       }
     ];

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -119,8 +119,13 @@ export class CodapHelper {
 
   static async configureUserCase(dataContextName: string, personalDataKey: string, personalDataLabel: string,
       alwaysCreate = false) {
-    const existingItemCount = await this.getItemCount(dataContextName);
-    if (alwaysCreate || (existingItemCount === 0)) {
+    // see if we have an existing case
+    const userCase = await codapInterface.sendRequest({
+      action: "get",
+      resource: collaboratorsResource(dataContextName, `caseSearch[${kCollaboratorKey}==${personalDataKey}]`)
+    });
+    const userCaseId = userCase && userCase.values && userCase.values[0] && userCase.values[0].id;
+    if (alwaysCreate || !userCaseId) {
       await codapInterface.sendRequest({
         action: "create",
         resource: collaboratorsResource(dataContextName, "case"),
@@ -133,7 +138,7 @@ export class CodapHelper {
     else {
       await codapInterface.sendRequest({
         action: "update",
-        resource: collaboratorsResource(dataContextName, "caseByIndex[0]"),
+        resource: collaboratorsResource(dataContextName, `caseByID[${userCaseId}]`),
         values: { values: { Name: personalDataLabel } }
       });
     }

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -358,10 +358,10 @@ export class CodapHelper {
     return null;
   }
 
-  static async getItemsOfCollaborator(dataContextName: string, userKey: string): Promise<any[]> {
+  static async getItemsOfCollaborator(dataContextName: string, personalDataKey: string): Promise<any[]> {
     const res = await codapInterface.sendRequest({
       action: "get",
-      resource: dataContextResource(dataContextName, `itemSearch[${kCollaboratorKey}==${userKey}]`)
+      resource: dataContextResource(dataContextName, `itemSearch[${kCollaboratorKey}==${personalDataKey}]`)
     });
     if (res.success) {
       return res.values;
@@ -369,10 +369,10 @@ export class CodapHelper {
     return [];
   }
 
-  static async getCaseForCollaborator(dataContextName: string, userKey: string) {
+  static async getCaseForCollaborator(dataContextName: string, personalDataKey: string) {
     const res = await codapInterface.sendRequest({
       action: "get",
-      resource: collaboratorsResource(dataContextName, `caseSearch[${kCollaboratorKey}==${userKey}]`)
+      resource: collaboratorsResource(dataContextName, `caseSearch[${kCollaboratorKey}==${personalDataKey}]`)
     });
     // there should be only one such case
     return res.success && res.values && res.values.length ? res.values[0] : null;


### PR DESCRIPTION
This creates a unique user key for each user, and uses `[userkey]-[userlabel]` everywhere we used to use `userlabel`, except for the visible Name column.

This allows a user to return to their work, but makes it impossible for users working on other documents to be able to modify another user's data. 

It also allows a user to create a new row by changing their label, which lets users of shared documents refrain from clobbering each other's work. (However, it doesn't *prevent* users of shared documents from clobbering each other's work.)

Testing: A user can re-join a shared table with the same label, and they will be able to add to their previous work, or they can join with a new label, and they will start a new user row.

This PR omits saving to CODAP, which will be in its own PR.