### PR TITLE
Save and load state from CODAP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,13 +24,16 @@ const kShareIdLength = 6;
 const kNewSharedTable = "new-table";
 const kNewDataContextTitle = "Collaborative Table";
 
-interface IState {
+interface ISaveState {
+  personalDataKeyPrefix: string;
+  lastPersonalDataLabel: string;
+}
+
+interface IState extends ISaveState {
   availableDataContexts: DataContext[];
   selectedDataContext: string;
-  personalDataKeyPrefix: string;
   personalDataLabel: string;
   personalDataKey: string;
-  lastPersonalDataLabel: string;
   shareId?: string;
   joinShareId: string;
   isInProcessOfSharing: boolean;
@@ -61,8 +64,11 @@ class App extends Component {
 
   public componentDidMount() {
     Codap.initializePlugin(kPluginName, kVersion, kInitialDimensions)
-      .then(() => Codap.addDataContextsListListener(this.updateAvailableDataContexts))
-      .then(this.updateAvailableDataContexts);
+      .then((loadState: any) => {
+        this.setState(loadState as ISaveState);
+        Codap.addDataContextsListListener(this.updateAvailableDataContexts);
+        this.updateAvailableDataContexts();
+      });
 
     database = new DB({
       itemsAdded: this.itemsAdded,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ChangeEvent } from "react";
 import * as randomize from "randomatic";
-import { CodapHelper as Codap, DataContext} from "./lib/codap-helper";
+import { CodapHelper as Codap, DataContext, ISaveState} from "./lib/codap-helper";
 import { ClientNotification } from "./lib/CodapInterface";
 import { ClientItemValues } from "./lib/firebase-handlers";
 import { DB, SharedTableEntry } from "./lib/db";
@@ -23,11 +23,6 @@ const kShareIdLength = 6;
 
 const kNewSharedTable = "new-table";
 const kNewDataContextTitle = "Collaborative Table";
-
-interface ISaveState {
-  personalDataKeyPrefix: string;
-  lastPersonalDataLabel: string;
-}
 
 interface IState extends ISaveState {
   availableDataContexts: DataContext[];
@@ -64,8 +59,8 @@ class App extends Component {
 
   public componentDidMount() {
     Codap.initializePlugin(kPluginName, kVersion, kInitialDimensions)
-      .then((loadState: any) => {
-        this.setState(loadState as ISaveState);
+      .then(loadState => {
+        this.setState(loadState);
         Codap.addDataContextsListListener(this.updateAvailableDataContexts);
         this.updateAvailableDataContexts();
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,15 @@ class App extends Component {
     });
   }
 
+  public componentDidUpdate(prevProps: {}, prevState: IState) {
+    if ((prevState.personalDataKey !== this.state.personalDataKey)
+          || (prevState.lastPersonalDataLabel !== this.state.lastPersonalDataLabel)) {
+
+      const { personalDataKeyPrefix, lastPersonalDataLabel } = this.state;
+      Codap.saveState({ personalDataKeyPrefix, lastPersonalDataLabel });
+    }
+  }
+
   public render() {
     if (!this.state.shareId) {
       Codap.resizePlugin(kInitialDimensions.width, kInitialDimensions.height);

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -2,6 +2,11 @@ import * as randomize from "randomatic";
 import codapInterface, { CodapApiResponse, ClientHandler, Collection, Attribute, IConfig } from "./CodapInterface";
 import { ClientItemValues } from "./firebase-handlers";
 
+export interface ISaveState {
+  personalDataKeyPrefix: string;
+  lastPersonalDataLabel: string;
+}
+
 export interface DataContextCreation {
   title: string;
   collections?: Collection[];
@@ -45,7 +50,7 @@ export class CodapHelper {
       dimensions
     };
     await codapInterface.init(interfaceConfig);
-    return await codapInterface.getInteractiveState();
+    return await codapInterface.getInteractiveState() as ISaveState;
   }
 
   static addDataContextsListListener(callback: ClientHandler) {
@@ -402,7 +407,7 @@ export class CodapHelper {
     return false;
   }
 
-  static saveState(state: any) {
+  static saveState(state: ISaveState) {
     codapInterface.updateInteractiveState(state);
   }
 }

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -44,7 +44,8 @@ export class CodapHelper {
       preventTopLevelReorg: true,
       dimensions
     };
-    return await codapInterface.init(interfaceConfig);
+    await codapInterface.init(interfaceConfig);
+    return await codapInterface.getInteractiveState();
   }
 
   static addDataContextsListListener(callback: ClientHandler) {

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -400,4 +400,8 @@ export class CodapHelper {
     }
     return false;
   }
+
+  static saveState(state: any) {
+    codapInterface.updateInteractiveState(state);
+  }
 }


### PR DESCRIPTION
This work-in-progress branch saves and loads the user's unique key and last-used label to CODAP.

This PR is on top of #22.

While the basic feature works, there is an issue with loading saved documents that is independent of the saving and loading (i.e. the saving and loading can be stripped out and the issue still remains). When you try to open a document that has been using a shared table, errors are thrown.

This can be reproduced without applying this PR simply by creating a table with the plugin, saving to local file, and loading. An error will be thrown either when loading or when you try to add data.