### PR TITLE
Prevent closing plugin/deleting non-empty attributes while sharing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,6 +277,7 @@ class App extends Component {
       const shareId = randomize("a0", kShareIdLength, { exclude: "0oOiIlL1" });
       this.setState({shareId});
       database.createSharedTable(shareId, personalDataKey);
+      Codap.configureForSharing(true);
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       await this.writeDataContext(updatedNewContext);
@@ -299,6 +300,7 @@ class App extends Component {
         return;
       }
       this.setState({shareId});
+      Codap.configureForSharing(true);
 
       const response = await database.getAll();
       const sharedContextData = response && response.val() as SharedTableEntry | undefined;
@@ -362,6 +364,7 @@ class App extends Component {
       joinShareId: ""
     });
     database.leaveSharedTable();
+    Codap.configureForSharing(false);
   }
 
   itemsAdded = async (user: string, items: ClientItemValues[]) => {

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -78,9 +78,12 @@ export interface IConfig {
   title?: string;
   version?: string;
   dimensions?: IDimensions;
+  cannotClose?: boolean;
   preventBringToFront?: boolean;
   preventDataContextReorg?: boolean;
   preventTopLevelReorg?: boolean;
+  preventAttributeDeletion?: boolean;
+  allowEmptyAttributeDeletion?: boolean;
 }
 
 var config: IConfig | null = null;
@@ -112,6 +115,7 @@ export type ClientHandler = (notification: ClientNotification) => void;
 export interface Attribute {
   name: string;
   editable?: boolean;
+  deleteable?: boolean;
   hidden?: boolean;
 }
 

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -47,6 +47,8 @@ export class CodapHelper {
       version,
       preventDataContextReorg: false,
       preventTopLevelReorg: true,
+      preventAttributeDeletion: false,
+      allowEmptyAttributeDeletion: true,
       dimensions
     };
     await codapInterface.init(interfaceConfig);
@@ -216,7 +218,7 @@ export class CodapHelper {
           pluralCase: "names"
         },
         attrs: [
-          {name: "Name", editable: false},
+          {name: "Name", editable: false, deleteable: false},
           {name: kCollaboratorKey, editable: false, hidden: true}
         ]
       }
@@ -349,6 +351,17 @@ export class CodapHelper {
           width,
           height
         }
+      }
+    });
+  }
+
+  static configureForSharing(isSharing: boolean) {
+    codapInterface.sendRequest({
+      action: "update",
+      resource: "interactiveFrame",
+      values: {
+        cannotClose: isSharing,
+        preventAttributeDeletion: isSharing
       }
     });
   }

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -45,6 +45,7 @@ export class CodapHelper {
     const interfaceConfig: IConfig = {
       name: pluginName,
       version,
+      cannotClose: false,
       preventDataContextReorg: false,
       preventTopLevelReorg: true,
       preventAttributeDeletion: false,


### PR DESCRIPTION
1. Prevent closing plugin while sharing
2. Prevent deleting non-empty attributes while sharing

Note: this relies on [CODAP PR#273](https://github.com/concord-consortium/codap/pull/273).