### PR TITLE
Case table prevents editing of other users' rows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,6 +313,7 @@ class App extends Component {
         if (!existingDataContext) {
           const newDataContext = await Codap.createDataContext(sharedDataContext);
           if (newDataContext) {
+            await Codap.addEditableAttribute(newDataContext, personalDataKey);
             ownDataContextName = newDataContext.name;
             this.setState({ selectedDataContext: ownDataContextName });
           } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { Component, ChangeEvent } from "react";
 import * as randomize from "randomatic";
 import { CodapHelper as Codap, DataContext, ISaveState} from "./lib/codap-helper";
-import { ClientNotification } from "./lib/CodapInterface";
+import codapInterface, { ClientNotification } from "./lib/CodapInterface";
 import { ClientItemValues } from "./lib/firebase-handlers";
 import { DB, SharedTableEntry } from "./lib/db";
 const pkg = require("../package.json");
@@ -25,6 +25,7 @@ const kNewSharedTable = "new-table";
 const kNewDataContextTitle = "Collaborative Table";
 
 interface IState extends ISaveState {
+  id: string;
   availableDataContexts: DataContext[];
   selectedDataContext: string;
   personalDataLabel: string;
@@ -40,6 +41,7 @@ let database: DB;
 class App extends Component {
 
   public state: IState = {
+    id: "",
     availableDataContexts: [],
     selectedDataContext: kNewSharedTable,
     personalDataKeyPrefix: randomize("a0", 10),
@@ -60,7 +62,8 @@ class App extends Component {
   public componentDidMount() {
     Codap.initializePlugin(kPluginName, kVersion, kInitialDimensions)
       .then(loadState => {
-        this.setState(loadState);
+        const interactiveFrame = codapInterface.getInitialInteractiveFrame();
+        this.setState({ id: interactiveFrame.id, ...loadState });
         Codap.addDataContextsListListener(this.updateAvailableDataContexts);
         this.updateAvailableDataContexts();
       });
@@ -277,7 +280,7 @@ class App extends Component {
       const shareId = randomize("a0", kShareIdLength, { exclude: "0oOiIlL1" });
       this.setState({shareId});
       database.createSharedTable(shareId, personalDataKey);
-      Codap.configureForSharing(true);
+      Codap.configureForSharing(dataContextName, this.state.id, true);
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       await this.writeDataContext(updatedNewContext);
@@ -300,7 +303,6 @@ class App extends Component {
         return;
       }
       this.setState({shareId});
-      Codap.configureForSharing(true);
 
       const response = await database.getAll();
       const sharedContextData = response && response.val() as SharedTableEntry | undefined;
@@ -327,6 +329,7 @@ class App extends Component {
 
           await this.writeDataContext(selectedDataContext);
         }
+        Codap.configureForSharing(ownDataContextName, this.state.id, true);
 
         // listeners must be added after data context is configured
         database.installUserItemListeners();
@@ -358,6 +361,7 @@ class App extends Component {
   }
 
   leaveShare = () => {
+    Codap.configureForSharing(this.state.selectedDataContext, this.state.id, false);
     this.setState({
       shareId: null,
       selectedDataContext: kNewSharedTable,
@@ -365,7 +369,6 @@ class App extends Component {
       joinShareId: ""
     });
     database.leaveSharedTable();
-    Codap.configureForSharing(false);
   }
 
   itemsAdded = async (user: string, items: ClientItemValues[]) => {

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -95,6 +95,11 @@ export interface CodapApiResponse {
 }
 
 /**
+ * A cached copy of the initial interactiveFrame response
+ */
+var initialInteractiveFrame: any = {};
+
+/**
  * A serializable object shared with CODAP. This is saved as a part of the
  * CODAP document. It is intended for the data interactive's use to store
  * any information it may need to reestablish itself when a CODAP document
@@ -121,6 +126,7 @@ export interface Attribute {
   precision?: string;
   unit?: string;
   editable?: boolean;
+  renameable?: boolean;
   deleteable?: boolean;
   hidden?: boolean;
 }
@@ -243,6 +249,7 @@ const codapInterface = {
         var success = resp && resp[1] && resp[1].success;
         var receivedFrame = success && resp[1].values;
         var savedState = receivedFrame && receivedFrame.savedState;
+        this_.updateInitialInteractiveFrame(receivedFrame);
         this_.updateInteractiveState(savedState);
         if (success) {
           // deprecated way of conveying state
@@ -306,6 +313,15 @@ const codapInterface = {
   },
 
   /**
+   * Returns a copy of the initial interactive frame response.
+   *
+   * @returns {object}
+   */
+  getInitialInteractiveFrame: function () {
+    return initialInteractiveFrame;
+  },
+
+  /**
    * Returns the interactive state.
    *
    * @returns {object}
@@ -318,10 +334,15 @@ const codapInterface = {
    * Updates the interactive state.
    * @param iInteractiveState {Object}
    */
+  updateInitialInteractiveFrame: function (iInteractiveFrame: any) {
+    initialInteractiveFrame = Object.assign(initialInteractiveFrame, iInteractiveFrame);
+  },
+
+  /**
+   * Updates the interactive state.
+   * @param iInteractiveState {Object}
+   */
   updateInteractiveState: function (iInteractiveState: any) {
-    if (!iInteractiveState) {
-      return;
-    }
     interactiveState = Object.assign(interactiveState, iInteractiveState);
   },
 

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -84,6 +84,7 @@ export interface IConfig {
   preventTopLevelReorg?: boolean;
   preventAttributeDeletion?: boolean;
   allowEmptyAttributeDeletion?: boolean;
+  respectEditableItemAttribute?: boolean;
 }
 
 var config: IConfig | null = null;

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -439,16 +439,25 @@ export class CodapHelper {
     });
   }
 
-  static configureForSharing(isSharing: boolean) {
-    codapInterface.sendRequest({
-      action: "update",
-      resource: "interactiveFrame",
-      values: {
-        cannotClose: isSharing,
-        preventAttributeDeletion: isSharing,
-        respectEditableItemAttribute: isSharing
+  static configureForSharing(dataContextName: string, controllerId: string, isSharing: boolean) {
+    codapInterface.sendRequest([
+      {
+        action: "update",
+        resource: dataContextResource(dataContextName),
+        values: {
+          managingController: isSharing ? controllerId : "__none__"
+        }
+      },
+      {
+        action: "update",
+        resource: "interactiveFrame",
+        values: {
+          cannotClose: isSharing,
+          preventAttributeDeletion: isSharing,
+          respectEditableItemAttribute: isSharing
+        }
       }
-    });
+    ]);
   }
 
   static async getDataContext(dataContextName: string): Promise<DataContext | null> {


### PR DESCRIPTION
In consultation with @jsandoe , the approach taken here is:
1. Add a hidden `__editable__` attribute at the top-level with a formula that sets the value of the attribute according to the contents of the `__collaborator__` attribute.
2. Set the value of the `managingController` property for any DataContext we're sharing.
3. Set the value of the `respectEditableItemAttribute` property on the plugin

The result is that the "special" properties enabled by the plugin/GameController (`preventDataContextReorg`, ..., `respectEditableItemAttribute`) are only enabled while the collection is being shared.

Note that this PR relies on [CODAP PR#275](https://github.com/concord-consortium/codap/pull/275)