### PR TITLE
Fixes initial join issue; enables synchronization of attribute deletion

### DIFF
--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -401,16 +401,16 @@ export class CodapHelper {
       // After initial join we allow destructive syncing
       // Disabled for now, as we still have echo effects that sometimes
       // cause attributes to be deleted incorrectly on initial join.
-      // if (!initialJoin) {
-      //   const staleAttributes = originalAttributes.filter(attrA => {
-      //     return !sharedAttributes.some(attrB => attrA.name === attrB.name);
-      //   });
+      if (!initialJoin) {
+        const staleAttributes = originalAttributes.filter(attrA => {
+          return !sharedAttributes.some(attrB => attrA.name === attrB.name);
+        });
 
-      //   changeCommands.push(...staleAttributes.map(attr => ({
-      //     action: "delete",
-      //     resource: collectionResource(dataContext.name, attr.collection, `attribute[${attr.name}]`)
-      //   })));
-      // }
+        changeCommands.push(...staleAttributes.map(attr => ({
+          action: "delete",
+          resource: collectionResource(dataContext.name, attr.collection, `attribute[${attr.name}]`)
+        })));
+      }
       await codapInterface.sendRequest(changeCommands);
     }
   }


### PR DESCRIPTION
Fixes initial join issue in which items with new attributes would be written to firebase before the data context that defined those attributes due to debouncing. The result was that when joining with an existing data context with preexisting cases, the preexisting case values for the new attribute(s) would not be shared to prior users. 

The debounce is moved to the codap notification response path to limit writes to firebase triggered by codap notifications in a way that doesn't affect the initial share/join.

Enables attribute deletion in syncDataContexts now that debouncing can't confuse the initial join/share path.