### PR TITLE
Don't delete protected attributes in `syncDataContexts()`

### DIFF
--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -402,9 +402,12 @@ export class CodapHelper {
       // Disabled for now, as we still have echo effects that sometimes
       // cause attributes to be deleted incorrectly on initial join.
       if (!initialJoin) {
-        const staleAttributes = originalAttributes.filter(attrA => {
-          return !sharedAttributes.some(attrB => attrA.name === attrB.name);
-        });
+        const staleAttributes = originalAttributes
+                                  .filter(attrA => {
+                                    return !sharedAttributes.some(attrB => attrA.name === attrB.name);
+                                  })
+                                  // don't delete protected attributes (like __editable__)
+                                  .filter(attr => attr.attr.deleteable);
 
         changeCommands.push(...staleAttributes.map(attr => ({
           action: "delete",


### PR DESCRIPTION
Don't delete protected attributes in `syncDataContexts()`
- prevents deletion of the `__editable__` attribute

1. #28 enabled case table row locking via the use of an unshared `__editable__` attribute.
2. #30 enabled deletion of no-longer-shared attributes.
3. Uninteded consequence -- `__editable__` attribute is immediately deleted, disabling the row-locking functionality. 🤦‍♂️ 