### PR TITLE
Handle deletion of all cases properly

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
     "jsx-wrap-multiline": false,
     "max-classes-per-file": false,
     "member-access": false,
+    "member-ordering": false,
     "no-console": false,
     "no-debugger": false,
     "no-empty-interface": false,


### PR DESCRIPTION
Previously, we added a new collaborator case to the data on initiating/joining a share, but if a user deleted all of his/her cases, then that collaborator case was deleted as well. With this PR, we check whether the collaborator case is missing after data context changes and add it if necessary.

Note that this relies on a plugin API change implemented in CODAP [PR #279](https://github.com/concord-consortium/codap/pull/279).