### PR TITLE
Delete empty user items [#165511258]

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { Component, ChangeEvent } from "react";
 import randomize from "randomatic";
-import { CodapHelper as Codap, ISaveState} from "./lib/codap-helper";
+import { CodapHelper as Codap, ISaveState } from "./lib/codap-helper";
 import codapInterface, { ClientNotification } from "./lib/CodapInterface";
 import { DB } from "./lib/db";
 import { DBSharedTable } from "./lib/db-types";
@@ -39,7 +39,7 @@ interface IState extends ISaveState {
 
 let database: DB;
 
-class App extends Component {
+export default class App extends Component {
 
   public state: IState = {
     id: "",
@@ -240,7 +240,7 @@ class App extends Component {
       if (shareId && selectedDataContext) {
         const changes = await Codap.configureUnsharedCases(selectedDataContext, personalDataKey, personalDataLabel);
         if (changes && changes.length) {
-          codapInterface.sendRequest(changes);
+          await codapInterface.sendRequest(changes);
         }
       }
     }
@@ -253,7 +253,8 @@ class App extends Component {
 
   async writeUserItems(selectedDataContext: string, personalDataKey: string) {
     const items = await Codap.getItemsOfCollaborator(selectedDataContext, personalDataKey);
-    database.writeUserItems(personalDataKey, items);
+    // write non-empty user items to firebase
+    database.writeUserItems(personalDataKey, items.filter(item => !Codap.isEmptyUserItem(item)));
     return items;
   }
 
@@ -434,5 +435,3 @@ class App extends Component {
     Codap.moveUserItemsToLast(selectedDataContext, personalDataKey);
   }
 }
-
-export default App;

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -89,10 +89,12 @@ export interface IConfig {
 
 var config: IConfig | null = null;
 
-export interface CodapApiResponse {
+export interface CodapRequestResponse {
   success: boolean;
   values?: any;
 }
+
+export type CodapApiResponse = CodapRequestResponse | CodapRequestResponse[];
 
 /**
  * A cached copy of the initial interactiveFrame response


### PR DESCRIPTION
When sharing an empty collection, we create an "empty" user item (sometimes called a "ghost case" in PT stories) that has values for the required sharing attributes but no values for any other attributes. This is to ensure that user-entered items, e.g. items entered using the input row of the case table, will automatically be grouped with the appropriate sharing attribute values for the current user. Unfortunately, there are various circumstances under which this "empty" user item persists and can sometimes adversely influence how subsequent items are handled.

With this PR, we now endeavor to remove that "empty" user item when new items are added either by user entry or by other plugins that generate items.

Testable at https://codap.concord.org/releases/latest?di=https://codap-shared-table-plugin.concord.org/branch/delete-empty-items/.