### PR TITLE
Synchronize attribute renames [#165207889]

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ export interface Attribute {
   formula?: string;
   description?: string;
   type?: string;
+  cid?: string;
   precision?: string;
   unit?: string;
   editable?: boolean;


### PR DESCRIPTION
- use `cid` to match attributes rather than names after initial join