### PR TITLE
Fix data context menu behavior after restoring saved document

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,8 @@ export default class App extends Component {
     Codap.initializePlugin(kPluginName, kVersion, kInitialDimensions)
       .then(loadState => {
         const interactiveFrame = codapInterface.getInitialInteractiveFrame();
-        this.setState({ id: interactiveFrame.id, ...loadState });
+        const selectedDataContext = (loadState && loadState.lastSelectedDataContext) || "";
+        this.setState({ id: interactiveFrame.id, selectedDataContext, ...loadState });
         Codap.addDataContextsListListener(this.updateAvailableDataContexts);
         this.updateAvailableDataContexts();
       });


### PR DESCRIPTION
- the menu defaulted to the last saved data context, but the code defaulted to creating a new table