### PR TITLE
chore: Obfuscated Firebase API key [PT-187643494]

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,7 +4,7 @@ import { ClientItemsHandlers, FirebaseItemHandlers } from "./firebase-handlers";
 import { CodapItem } from "./types";
 
 const config = {
-  apiKey: "AIzaSyASCGi9fWCUX3orJVB9d6svJbxDHfSRJVA",
+  apiKey: atob("QUl6YVN5QVNDR2k5ZldDVVgzb3JKVkI5ZDZzdkpieERIZlNSSlZB"),
   authDomain: "codap-shared-table-plugin.firebaseapp.com",
   databaseURL: "https://codap-shared-table-plugin.firebaseio.com"
 };


### PR DESCRIPTION
Obfuscated Firebase API key using atob() so that automated key leak detectors are not falsely triggered.

NOTE: the Firebase API key is a public key so this does not leak secrets.