### PR TITLE
187178550 Batch Delete Item Requests

### DIFF
--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -296,6 +296,10 @@ const codapInterface = {
     return initialInteractiveFrame;
   },
 
+  getCodapVersion() {
+    return this.getInitialInteractiveFrame().codapVersion;
+  },
+
   /**
    * Returns the interactive state.
    *

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -224,13 +224,12 @@ export class CodapHelper {
                             ? unsharedResult.values : [];
     const requests: CodapRequest[] = [];
     if (emptyItems.length && (nonEmptyItemCount || unsharedCases.length)) {
-      emptyItems.forEach(item => {
-                  // delete any "empty" user items as long as there are non-empty user items
-                  requests.push({
-                    action: "delete",
-                    resource: collaboratorsResource(dataContextName, `itemByID[${item.id}]`),
-                  });
-                });
+      // delete any "empty" user items as long as there are non-empty user items
+      requests.push({
+        action: "delete",
+        resource: collaboratorsResource(dataContextName, `item`),
+        values: emptyItems.map(item => ({ id: item.id }))
+      })
     }
     // apply required sharing values to currently "unshared" cases.
     // this occurs when items are generated from other plugins, for instance.
@@ -305,11 +304,11 @@ export class CodapHelper {
   }
 
   static async removeItems(dataContextName: string, itemValues: CodapItem[]) {
-    const requests = itemValues.map(item => ({
-            action: "delete",
-            resource: dataContextResource(dataContextName, `itemByID[${item.id}]`)
-          }));
-    return codapInterface.sendRequest(requests);
+    return codapInterface.sendRequest({
+      action: "delete",
+      resource: dataContextResource(dataContextName, `item`),
+      values: itemValues.map(item => ({ id: item.id }))
+    });
   }
 
   static async addNewCollaborationCollections(dataContextName: string, personalDataKey: string,

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -314,7 +314,6 @@ export class CodapHelper {
   }
 
   static async removeItems(dataContextName: string, itemValues: CodapItem[]) {
-    console.log(`--- removeItems`, codapInterface.getCodapVersion())
     if (codapInterface.getCodapVersion()) {
       // Codap v3 (when codapVersion began to be sent) supports batched delete item requests
       return codapInterface.sendRequest({

--- a/src/lib/firebase-handlers.ts
+++ b/src/lib/firebase-handlers.ts
@@ -57,7 +57,7 @@ export class FirebaseItemHandlers {
       this.clientHandlers.itemsAdded(this.user, items);
 
       this.orderedItemIds = itemData.order;
-      items.forEach(item => this.itemIds.add(item.id));
+      items.forEach(item => this.itemIds.add(`${item.id}`));
     }
   };
 
@@ -80,12 +80,12 @@ export class FirebaseItemHandlers {
       if (this.addItemsQueue.length) {
         const items = this.sortedQueuedItems();
         this.clientHandlers.itemsAdded(this.user, items);
-        items.forEach(item => this.itemIds.add(item.id));
+        items.forEach(item => this.itemIds.add(`${item.id}`));
         this.addItemsQueue = [];
       }
       if (this.removeItemsQueue.length) {
         this.clientHandlers.itemsRemoved(this.user, this.removeItemsQueue);
-        this.removeItemsQueue.forEach(item => this.itemIds.delete(item.id));
+        this.removeItemsQueue.forEach(item => this.itemIds.delete(`${item.id}`));
         this.removeItemsQueue = [];
       }
     }


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/187178550

This PR takes advantage of new features to make deleting cases more efficient.
- The plugin now behaves differently based on the version of Codap it's embedded within.
- When in v3, the plugin now takes advantage of the new batching feature of the `delete item` API request, greatly speeding up the removal of large numbers of cases.

This PR also fixes a bug where ids were not being removed from the `itemIds` set in `firebase-handlers.ts`, because they were being saved as strings in the set but were being removed as numbers.