### PR TITLE
188115683 Remove Placeholder Item When Possible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -257,6 +257,13 @@ export default class App extends Component {
 
   async writeUserItems(selectedDataContext: string, personalDataKey: string) {
     const items = await Codap.getItemsOfCollaborator(selectedDataContext, personalDataKey);
+
+    // Remove the first item if it has no values, i.e. the placeholder item for this user
+    if (items.length > 1 && Codap.isValuelessUserItem(items[0])) {
+      await Codap.removeItems(selectedDataContext, [items[0]]);
+      items.shift();
+    }
+    
     // write non-empty user items to firebase
     database.writeUserItems(personalDataKey, items.filter(item => !Codap.isEmptyUserItem(item)));
     return items;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188115683

This PR fixes the issue of a user's placeholder item sticking around in a shared table after it is no longer useful. Whenever cases are added by a user, the top case is removed if it has no values and there is at least one additional case.

Other improvements:
- Removes an extra `create collection` API request.
- Minor code cleanup.