### PR TITLE
188104356  Make Shared Table Block API Requests

### DIFF
--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -88,6 +88,7 @@ export interface IConfig {
   preventTopLevelReorg?: boolean;
   preventAttributeDeletion?: boolean;
   allowEmptyAttributeDeletion?: boolean;
+  blockAPIRequests?: boolean;
   respectEditableItemAttribute?: boolean;
 }
 

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -88,7 +88,7 @@ export interface IConfig {
   preventTopLevelReorg?: boolean;
   preventAttributeDeletion?: boolean;
   allowEmptyAttributeDeletion?: boolean;
-  blockAPIRequests?: boolean;
+  blockAPIRequestsWhileEditing?: boolean;
   respectEditableItemAttribute?: boolean;
 }
 

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -54,7 +54,7 @@ export class CodapHelper {
       preventTopLevelReorg: true,
       preventAttributeDeletion: false,
       allowEmptyAttributeDeletion: true,
-      blockAPIRequests: true,
+      blockAPIRequestsWhileEditing: true,
       respectEditableItemAttribute: true,
       dimensions
     };

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -54,6 +54,7 @@ export class CodapHelper {
       preventTopLevelReorg: true,
       preventAttributeDeletion: false,
       allowEmptyAttributeDeletion: true,
+      blockAPIRequests: true,
       respectEditableItemAttribute: true,
       dimensions
     };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188104356

This PR makes the Collaborative plugin specify that editing a shared table should block API requests from being processed.