### PR TITLE
Don't show error message if user goes back from last page.

### DIFF
--- a/src/ui-pages/join-and-merge-table.tsx
+++ b/src/ui-pages/join-and-merge-table.tsx
@@ -46,7 +46,7 @@ export const JoinAndMergeTable = (props: JoinAndMergeTableProps) => {
       <div className="button-row">
         <button
           className="cancel-button"
-          onClick={() => updateState({ joinAndMergeTable: false })}>
+          onClick={() => updateState({ joinAndMergeTable: false, showJoinShareError: false })}>
           {BACK}
         </button>
         <button

--- a/src/ui-pages/join-without-merging.tsx
+++ b/src/ui-pages/join-without-merging.tsx
@@ -29,7 +29,7 @@ export const JoinWithoutMerging = (props: JoinWithoutMergingProps) => {
       <div className="button-row">
         <button
           className="cancel-button"
-          onClick={() => updateState({ joinWithoutMerging: false })}>
+          onClick={() => updateState({ joinWithoutMerging: false, showJoinShareError: false })}>
             {BACK}
         </button>
         <button


### PR DESCRIPTION
Fixes this issue:
- If you put in a an incorrect code, an error message is displayed that doesn't go away if you go to another screen through the "bacK" button.