### PR TITLE
188279613 Fix Share Existing Again

### DIFF
--- a/src/ui-pages/join-and-merge-table.tsx
+++ b/src/ui-pages/join-and-merge-table.tsx
@@ -13,7 +13,7 @@ interface JoinAndMergeTableProps {
   handleDataContextChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   handleJoinShareIdChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleDataLabelChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  joinShare: () => void;
+  joinShare: (selectedContext?: string) => void;
   updateState: (state: Partial<IState>) => void;
 }
 
@@ -51,7 +51,7 @@ export const JoinAndMergeTable = (props: JoinAndMergeTableProps) => {
         </button>
         <button
           disabled={!selectedContextOption || !joinShareId || (!personalDataLabel && !lastPersonalDataLabel)}
-          onClick={joinShare}
+          onClick={() => joinShare(selectedContextOption)}
         >
             {BEGIN_COLLABORATION}
         </button>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188279613

The last attempt to fix this bug resulted in the correct table being shared, but new data was then being added to the wrong parent case. This PR fixes the bug by making `joinShare` work the same way as `initiateShare`, namely by setting `selectedDataContext` in state when appropriate.