### PR TITLE
188104291 Return special attributes to normal when unsharing a table.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,7 +370,7 @@ export default class App extends Component {
       const shareId = randomize("a0", kShareIdLength, { exclude: "0oOiIlL1" });
       this.setState({shareId});
       database.createSharedTable(shareId, personalDataKey);
-      Codap.configureForSharing(dataContextName, this.state.id, true);
+      Codap.configureForSharing(dataContextName, this.state.id, this.state.personalDataKey, true);
 
       const updatedNewContext = await Codap.getDataContext(dataContextName);
       await this.writeDataContext(updatedNewContext);
@@ -422,7 +422,7 @@ export default class App extends Component {
 
           await this.writeDataContext(selectedDataContext);
         }
-        Codap.configureForSharing(ownDataContextName, this.state.id, true);
+        Codap.configureForSharing(ownDataContextName, this.state.id, personalDataKey, true);
 
         // listeners must be added after data context is configured
         database.installUserItemListeners();
@@ -453,7 +453,7 @@ export default class App extends Component {
   };
 
   leaveShare = () => {
-    Codap.configureForSharing(this.state.selectedDataContext, this.state.id, false);
+    Codap.configureForSharing(this.state.selectedDataContext, this.state.id, this.state.personalDataKey, false);
     this.setState({
       shareId: null,
       personalDataLabel: "",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/188104291

Previously, unsharing a table would not make the special attributes editable, renameable, or deleteable. This PR fixes that. If the table is reshared, the attributes regain their special status.

Note, though, that modifications the user makes while the table is unshared could cause problems when the table is reshared. Fixing these issues could be complex and time consuming, so we're accepting these problems for now.